### PR TITLE
Added support of managed and federated identities

### DIFF
--- a/deploy-adf-json/v2/package-lock.json
+++ b/deploy-adf-json/v2/package-lock.json
@@ -29,7 +29,7 @@
                 "prettier": "^2.6.2",
                 "sync-request": "^6.1.0",
                 "ts-node": "^10.7.0",
-                "typescript": "^4.6.4"
+                "typescript": "^4.9.5"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -3198,10 +3198,11 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "node_modules/typescript": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5757,9 +5758,9 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
         "uri-js": {

--- a/deploy-adf-json/v2/package.json
+++ b/deploy-adf-json/v2/package.json
@@ -32,6 +32,6 @@
         "prettier": "^2.6.2",
         "sync-request": "^6.1.0",
         "ts-node": "^10.7.0",
-        "typescript": "^4.6.4"
+        "typescript": "^4.9.5"
     }
 }

--- a/toggle-adf-trigger/v2/package-lock.json
+++ b/toggle-adf-trigger/v2/package-lock.json
@@ -29,7 +29,7 @@
                 "prettier": "^2.6.2",
                 "sync-request": "^6.1.0",
                 "ts-node": "^10.7.0",
-                "typescript": "^4.6.4"
+                "typescript": "^4.9.5"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -3198,10 +3198,11 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "node_modules/typescript": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5757,9 +5758,9 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
         "uri-js": {

--- a/toggle-adf-trigger/v2/package.json
+++ b/toggle-adf-trigger/v2/package.json
@@ -32,6 +32,6 @@
         "prettier": "^2.6.2",
         "sync-request": "^6.1.0",
         "ts-node": "^10.7.0",
-        "typescript": "^4.6.4"
+        "typescript": "^4.9.5"
     }
 }

--- a/toggle-adf-trigger/v2/toggleadftrigger.ts
+++ b/toggle-adf-trigger/v2/toggleadftrigger.ts
@@ -29,7 +29,7 @@
 import throat from "throat";
 import { error, warning, loc, setResourcePath, debug, TaskResult, setResult } from "azure-pipelines-task-lib/task";
 import { join } from "path";
-import { AccessToken, ClientSecretCredential } from "@azure/identity";
+import { AccessToken, ClientSecretCredential, DefaultAzureCredential, ManagedIdentityCredential } from "@azure/identity";
 import { AzureServiceClient } from "@azure/ms-rest-azure-js";
 import { HttpOperationResponse, RequestPrepareOptions, TokenCredentials } from "@azure/ms-rest-js";
 
@@ -54,17 +54,32 @@ function loginAzure(
     audience: string
 ): Promise<AzureServiceClient> {
     return new Promise<AzureServiceClient>((resolve, reject) => {
-        if (scheme.toLocaleLowerCase() === "managedserviceidentity") {
-            // loginWithAppServiceMSI()
-            //     .then((credentials: MSIAppServiceTokenCredentials) => {
-            //         resolve(new AzureServiceClient(credentials, {}));
-            //     })
-            //     .catch((err: Error) => {
-            //         if (err) {
-            //             error(loc("Generic_LoginAzure", err.message));
-            //             reject(loc("Generic_LoginAzure", err.message));
-            //         }
-            //     });
+        if (scheme.toLowerCase() === "managedserviceidentity") {
+            // Use Managed Identity credential
+            const credential = new ManagedIdentityCredential();
+            credential
+                .getToken(audience)
+                .then((accessToken: AccessToken) => {
+                    const token = new TokenCredentials(accessToken.token);
+                    resolve(new AzureServiceClient(token));
+                })
+                .catch((err: Error) => {
+                    error(loc("Generic_LoginAzure", err.message));
+                    reject(loc("Generic_LoginAzure", err.message));
+                });
+        } else if (scheme.toLowerCase() === "federated") {
+            // Use DefaultAzureCredential which supports federated identities
+            const credential = new DefaultAzureCredential();
+            credential
+                .getToken(audience)
+                .then((accessToken: AccessToken) => {
+                    const token = new TokenCredentials(accessToken.token);
+                    resolve(new AzureServiceClient(token));
+                })
+                .catch((err: Error) => {
+                    error(loc("Generic_LoginAzure", err.message));
+                    reject(loc("Generic_LoginAzure", err.message));
+                });
         } else {
             const credential = new ClientSecretCredential(tenantID, clientId, key, {
                 authorityHost: authorityHostUrl,


### PR DESCRIPTION
Added support of managed and federated identities for deploy-adf-json and toggle-adf-trigger

---

As all changes are publicly made available via PRs, you must agree to the terms before contributing:

- [ x] I represent that each of _my contributions_ is entirely _my original work_
- [ x] I have sole ownership of intellectual property rights to _my contribution_
- [ x] I approve that the community is free to use _my contribution_

Make sure that you have checked all tick boxes before this PR can be approved.

---
